### PR TITLE
Merge sleep fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: null-zero
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+.log
+.ipynb
+**/__pycache__/**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# selenium-pom-base
-Base project for selenium - page object model in Python
+# webstudentwork critter bot
+Automates the critter game using the Selenium Page Object Model
 
 ## Requirements
 

--- a/data/.env
+++ b/data/.env
@@ -1,0 +1,1 @@
+BASE_URL=

--- a/data/locators.py
+++ b/data/locators.py
@@ -1,4 +1,11 @@
 from selenium.webdriver.common.by import By
 
 class PageLocators:
-    BODY_EXAMPLE = (By.TAG_NAME, "body")
+
+    CARD_DECK = (By.CLASS_NAME, "card-deck")
+    CARDS = (By.CLASS_NAME, "cards")
+
+    PORTAL_NAME = (By.XPATH, "//div/h3")
+    PORTAL_TIMER = (By.ID, "timer")
+    PORTAL_STALENESS_CHECK_ELE = (By.XPATH, "//body/div[@class='container']/*[position()=2]")
+    

--- a/data/locators.py
+++ b/data/locators.py
@@ -1,11 +1,17 @@
 from selenium.webdriver.common.by import By
 
-class PageLocators:
 
+class PageLocators:
+    """
+    The `PageLocators` class contains Selenium locators for various elements on a web page.
+    """
     CARD_DECK = (By.CLASS_NAME, "card-deck")
     CARDS = (By.CLASS_NAME, "cards")
 
     PORTAL_NAME = (By.XPATH, "//div/h3")
     PORTAL_TIMER = (By.ID, "timer")
     PORTAL_STALENESS_CHECK_ELE = (By.XPATH, "//body/div[@class='container']/*[position()=2]")
-    
+
+    MERGE_NAME = (By.XPATH, "//div/h2")
+    MERGE_SUBMIT = (By.XPATH, "//div/form/input[@value='Merge Critters']")
+    MERGE_ERROR = (By.XPATH, "//*[text()[contains(., 'ERROR')]]")

--- a/main.py
+++ b/main.py
@@ -1,16 +1,20 @@
+import os
 from pathlib import Path
 from dotenv import load_dotenv
-
 from selenium import webdriver
 from selenium.webdriver.support.ui import WebDriverWait
-
 from pages.base_page import BasePage
-
-
+from pages.portals import Portals
 
 dotenv_path = Path('data/.env')
 load_dotenv(dotenv_path = dotenv_path)
+BASE_URL = os.environ.get("BASE_URL")
 
 driver = webdriver.Firefox()
 
-# base = BasePage(driver, WebDriverWait(driver, 35))
+base = BasePage(driver, WebDriverWait(driver, 35), BASE_URL)
+base.go_to_page(BASE_URL)
+base.wait_for_login()
+
+portals = Portals(base)
+portals.start_portal_loop()

--- a/main.py
+++ b/main.py
@@ -1,20 +1,39 @@
 import os
 from pathlib import Path
+from threading import Event
 from dotenv import load_dotenv
 from selenium import webdriver
 from selenium.webdriver.support.ui import WebDriverWait
 from pages.base_page import BasePage
 from pages.portals import Portals
+from pages.merging import Merging
 
+
+#: Safely get environment varables and assign to variable
 dotenv_path = Path('data/.env')
 load_dotenv(dotenv_path = dotenv_path)
 BASE_URL = os.environ.get("BASE_URL")
 
+
+#: Start a Selenium webdriver instance
 driver = webdriver.Firefox()
 
+
+#: Create the BasePage instance of Selenium's Page Object Model. Open url and wait to login.
 base = BasePage(driver, WebDriverWait(driver, 35), BASE_URL)
 base.go_to_page(BASE_URL)
 base.wait_for_login()
 
+
+#: Create an instance of Portals and an instance of Merging
 portals = Portals(base)
-portals.start_portal_loop()
+merging = Merging(base)
+
+
+#: Generate a threading.Event object so that we can start and stop the event loop threads when we need to.
+event = Event()
+
+
+#: Start the event loops
+portals.start_portal_loop(event)
+merging.start_merge_loop(event)

--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -1,11 +1,20 @@
+from selenium.webdriver.support import expected_conditions as EC
+from data.locators import PageLocators
+
 class BasePage:
 
-    def __init__(self, driver, wait):
+    def __init__(self, driver, wait, url):
         self.driver = driver
         self.wait = wait
+        self.locator = PageLocators
+        self.base_url = url
 
     def go_to_page(self, url):
         self.driver.get(url)
 
     def get_title(self):
         return self.driver.title
+
+    def wait_for_login(self):
+        self.wait.until(EC.url_changes(self.driver.current_url))
+        self.wait.until(EC.presence_of_element_located(self.locator.CARD_DECK))

--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -2,19 +2,49 @@ from selenium.webdriver.support import expected_conditions as EC
 from data.locators import PageLocators
 
 class BasePage:
-
+    """
+    BasePage class modeled from the Selenium Page Object Model
+    """
     def __init__(self, driver, wait, url):
+        """
+        Constructor for the BasePage class.
+        
+        Args:
+            driver (:obj): Instance of a Selenium web driver. It is responsible for controlling the browser and interacting with web elements on the
+                page.
+            wait (:obj): Instance of a Selenium WebDriverWait class. Waits for an element to be present or visible before throwing an exception.
+                It is typically used to ensure that the web page has finished loading before interacting with its elements.
+            url (str): Base URL of the website that you want to automate. It is used to
+                navigate to different pages within the website.
+                
+        Attributes:
+            locator (:obj): Class instance of Selenium Page Locators.
+        """
         self.driver = driver
         self.wait = wait
-        self.locator = PageLocators
         self.base_url = url
+        self.locator = PageLocators
 
     def go_to_page(self, url):
+        """
+        Opens url in Selenium web driver
+
+        Args:
+            url (str): URL to open
+        """
         self.driver.get(url)
 
     def get_title(self):
+        """
+        Returns:
+            The title of the web page that is currently being displayed in the browser.
+        """
         return self.driver.title
 
     def wait_for_login(self):
+        """
+        Waits for the login process to complete by checking for a change in the URL and the
+            presence of a specific element.
+        """
         self.wait.until(EC.url_changes(self.driver.current_url))
         self.wait.until(EC.presence_of_element_located(self.locator.CARD_DECK))

--- a/pages/merging.py
+++ b/pages/merging.py
@@ -1,0 +1,89 @@
+import datetime
+from threading import Timer
+from selenium.webdriver.support import expected_conditions as EC
+from pages.base_page import BasePage
+
+
+class Merging(BasePage):
+    """
+    Merging class for managing the merging page and any relevant methods.
+    """
+    def __init__(self, parent):
+        """
+        Constructor for the Merging class.
+        
+        Args:
+            parent (:obj): The "parent" parameter is the BasePage object from which the current class 
+                is derived. It is used to access the driver, wait, base_url, and locator attributes of the parent class.
+                
+        Attributes:
+            merge_url (str): Uses base_url to generate a merge base url.
+            merge_timers (dict of str: str): Dict of merge name and last time of opening.
+        """
+        self.merge_url = parent.base_url + "/merge.php?merge="
+        self.merge_timers = {}
+        super().__init__(parent.driver, parent.wait, parent.base_url)
+
+    def merge(self, merge_url):
+        """
+        Checks if the current URL matches the merge URL, navigates to the merge URL if
+        necessary, waits for the merge page to load, checks for the merge error message, clicks the merge submit
+        button if no errors are found, and returns an array of the merge name and current datetime.
+        
+        Args:
+            merge_url (str): URL of the current targeted merging level page.
+        
+        Returns:
+            Returns either `False` or a list containing the merge name and the current date and time.
+        """
+        if not merge_url in self.driver.current_url:
+            self.go_to_page(merge_url)
+            self.wait.until(EC.url_to_be(merge_url))
+            self.wait.until(EC.visibility_of_element_located(self.locator.MERGE_NAME))
+            self.wait.until(EC.text_to_be_present_in_element(self.locator.MERGE_NAME, "Merging"))
+        merge_error = self.driver.find_elements(*self.locator.MERGE_ERROR)
+        if not merge_error:
+            self.wait.until(EC.element_to_be_clickable(self.locator.MERGE_SUBMIT)).click()
+            return False
+        merge_name = self.wait.until(EC.visibility_of_element_located(self.locator.MERGE_NAME)).text
+        return [merge_name , datetime.datetime.now().strftime("%m/%d/%Y, %H:%M:%S")]
+
+    def merge_all(self, _min, _max, event):
+        """
+            Iterates through a range of merge IDs, sets the URL for each merge page and opens it using
+            the merge() class method. While merge() returns False and the threading.Event flag is not set, continue merging.
+            If threading.Event flag is set, return quietly. If merge() returns with a list, set or append current merge
+            name and current datetime to the class instance dictionary attribute, merge_timers.
+        
+        Args:
+            _min (int): Sets the lower bound of the merge IDs to loop through. It
+                determines the starting point of the loop.
+            _max (int): Sets the upper bound of the merge IDs to loop through. It is used to
+                determine the range of merge ID's to iterate over in the `merge_all` method.
+            event (:obj): Instance of the threading.Event class. It is used to
+                synchronize and communicate between different threads. Controls the
+                execution of the loop by setting and clearing the event flag.
+        """
+        _max = _max + 1
+        current_merge = self.merge_url + str(_min + len(self.merge_timers)) #: Calculate current merging url by getting the count of key value pairs in merge_timers.
+        res = False
+        while res is False:
+            if event.is_set():
+                break
+            res = self.merge(current_merge)
+        if not event.is_set():
+            merge_name, merge_time = res
+            self.merge_timers[merge_name] = [merge_time]
+            print(f"[{merge_time}]: Ran out of '{merge_name.replace(' Merging', '')}' merges.")
+
+    def start_merge_loop(self, event):
+        """
+        Starts a merge event loop, runs the merge_all() class method, and starts a threading.Timer object to generate a perpetual timed loop of itself.
+        
+        Args:
+            event (:obj): Instance of the threading.Event class. It is used to
+                synchronize and communicate between different threads. Controls the
+                execution of the loop by setting and clearing the event flag.
+        """
+        self.merge_all(3, 7, event)
+        Timer(0.3, self.start_merge_loop, [event]).start()

--- a/pages/portals.py
+++ b/pages/portals.py
@@ -1,36 +1,82 @@
 import datetime
-import threading
 from threading import Timer
 from selenium.webdriver.support import expected_conditions as EC
 from pages.base_page import BasePage
 
-class Portals(BasePage):
-    def __init__(self, instance):
-        self.locator = instance.locator
-        self.portal_url = instance.base_url + "/portaltest.php?portal="
-        self.portal_timers = {}
-        self.portal_lock = threading.Lock()
-        super().__init__(instance.driver, instance.wait, instance.base_url)
 
-    def open(self, portal):
+class Portals(BasePage):
+    """
+    Portals class for managing the portal page and any relevant methods.
+    """
+    def __init__(self, parent):
+        """
+        Constructor for the Portals class.
+        
+        Args:
+            parent (:obj): The "parent" parameter is the BasePage object from which the current class 
+                is derived. It is used to access the driver, wait, base_url, and locator attributes of the parent class.
+            
+        Attributes:
+            portal_url (str): Uses base_url to generate a portal base url.
+            portal_timers (dict of str: str): Dict of portal name and last time of opening.
+        """
+        self.portal_url = parent.base_url + "/portaltest.php?portal="
+        self.portal_timers = {}
+        super().__init__(parent.driver, parent.wait, parent.base_url)
+
+    def open(self, portal: str):
+        """
+        Opens a portal, waits for the page to load, checks for staleness of an element,
+            retrieves the portal name, and returns the portal name and the current date and time.
+        
+        Args:
+            portal (str): The "portal" parameter is a string that represents the URL of the portal that needs
+                to be opened.
+        
+        Returns:
+            The open() method returns a list containing the portal name and the current date and time in the
+        format "mm/dd/yyyy, hh:mm:ss".
+        """
         staleness_check_ele = self.driver.find_element(*self.locator.PORTAL_STALENESS_CHECK_ELE)
         self.go_to_page(portal)
         self.wait.until(EC.url_to_be(portal))
         self.wait.until(EC.staleness_of(staleness_check_ele))
         portal_name = self.wait.until(EC.visibility_of_element_located(self.locator.PORTAL_NAME)).text
-        print([portal_name, datetime.datetime.now().strftime("%m/%d/%Y, %H:%M:%S")])
         return [portal_name, datetime.datetime.now().strftime("%m/%d/%Y, %H:%M:%S")]
 
-    def open_all(self, _min, _max):
+    def open_all(self, _min: int, _max: int):
+        """
+        Iterates through a range of portal IDs, sets the URL for each portal, opens
+            it, and records the portal name and opening time as a dictionary in the instances portal_timers attribute.
+        
+        Args:
+            _min (int): Sets the lower bound of the portal IDs to loop through. It
+                determines the starting point of the loop.
+            _max (int): Sets the upper bound of the portal IDs to loop through. It is used to
+                determine the range of portal ID's to iterate over in the `open_all` method.
+        """
         _max = _max + 1
         for i in range(_min, _max):
             base_portal_id = 310
             current_portal = self.portal_url + str(base_portal_id + i)
             portal_name, portal_time = self.open(current_portal)
             self.portal_timers[portal_name] = [portal_time]
+            if i == _max - 1:
+                print(f'[{portal_time}]: Portal opening routine completed.')
 
-    def start_portal_loop(self):
-        with self.portal_lock:
-            self.open_all(2, 8)
-            portal_timer = Timer(120.0, self.start_portal_loop)
-            portal_timer.start()
+    def start_portal_loop(self, event):
+        """
+        Starts a portal event loop, sets a threading event flag to break out of ongoing threads, runs
+        the open_all() method, sets a timer to generate a perpetually timed loop, and clears the event flag
+        after finishing.
+        
+        Args:
+            event (:obj): Instance of the threading.Event class. It is used to
+                synchronize and communicate between different threads. Controls the
+                execution of the loop by setting and clearing the event flag.
+        """
+        event.set()
+        self.open_all(2, 8)
+        portal_timer = Timer(120.0, self.start_portal_loop, [event])
+        portal_timer.start()
+        event.clear()

--- a/pages/portals.py
+++ b/pages/portals.py
@@ -1,0 +1,36 @@
+import datetime
+import threading
+from threading import Timer
+from selenium.webdriver.support import expected_conditions as EC
+from pages.base_page import BasePage
+
+class Portals(BasePage):
+    def __init__(self, instance):
+        self.locator = instance.locator
+        self.portal_url = instance.base_url + "/portaltest.php?portal="
+        self.portal_timers = {}
+        self.portal_lock = threading.Lock()
+        super().__init__(instance.driver, instance.wait, instance.base_url)
+
+    def open(self, portal):
+        staleness_check_ele = self.driver.find_element(*self.locator.PORTAL_STALENESS_CHECK_ELE)
+        self.go_to_page(portal)
+        self.wait.until(EC.url_to_be(portal))
+        self.wait.until(EC.staleness_of(staleness_check_ele))
+        portal_name = self.wait.until(EC.visibility_of_element_located(self.locator.PORTAL_NAME)).text
+        print([portal_name, datetime.datetime.now().strftime("%m/%d/%Y, %H:%M:%S")])
+        return [portal_name, datetime.datetime.now().strftime("%m/%d/%Y, %H:%M:%S")]
+
+    def open_all(self, _min, _max):
+        _max = _max + 1
+        for i in range(_min, _max):
+            base_portal_id = 310
+            current_portal = self.portal_url + str(base_portal_id + i)
+            portal_name, portal_time = self.open(current_portal)
+            self.portal_timers[portal_name] = [portal_time]
+
+    def start_portal_loop(self):
+        with self.portal_lock:
+            self.open_all(2, 8)
+            portal_timer = Timer(120.0, self.start_portal_loop)
+            portal_timer.start()


### PR DESCRIPTION
Removed the merging timer and added a hard-coded sleep.
This avoids creating extra threads that break the merging sleep. Since the portals are still on their own threading.Timer, it is unaffected by the hard-coded sleep.